### PR TITLE
Correctie afleiding valversnelling

### DIFF
--- a/theorie_natuurkunde.tex
+++ b/theorie_natuurkunde.tex
@@ -496,9 +496,9 @@
     $$\Luda$$
     $$W = \lim_{\Delta l_{i} \to 0}\sum F_{i}\cos{\theta_{i}}\Delta l_{i}$$
     $$\Luda$$
-    $$W = \int_{a}^{b} F\cos{\theta}\Delta l \,dx $$ 
+    $$W = \int_{a}^{b} F\cos{\theta}\Delta l $$ 
     $$\Luda$$
-    $$W = \int_{a}^{b} \vec{F} \cdot d\vec{\emph{l}} \, dx $$
+    $$W = \int_{a}^{b} \vec{F} \cdot d\vec{\emph{l}} $$
     
     Dit is algemeen geldig voor elke ruimtedimensie (x, y en z). We kunnen dus in het algemeen schrijven:
     

--- a/theorie_natuurkunde.tex
+++ b/theorie_natuurkunde.tex
@@ -405,7 +405,9 @@
     $$\Luda$$
     $$ F_{g} = mg $$
     $$\Luda$$
-    $$ F_{g} = G\frac{M_{a}}{R_{a}^{2}} $$
+    $$ mg = G\frac{mM_{a}}{R_{a}^{2}}$$
+    $$\Luda$$
+    $$ g = G\frac{M_{a}}{R_{a}^{2}} $$
     $$\Luda$$
     $$ g = 9.81 \frac{m}{s^{2}} $$
     


### PR DESCRIPTION
Er stond een kleine fout in de afleiding van de valversnelling, Fg werd gelijkgesteld aan G * (Ma/R^2), dit klopt niet, g is hier wel gelijk aan. Fg is gelijk aan G * (mMa/R^2) zoals boven de afleiding staat. However als we een tussenstap toevoegen waarbij mg = G * (mMa/R^2) kunnen we de m naar de andere kant brengen en hebben we g = G * (Ma/R^2). Dit is ook hoe de afleiding gebeurde in de giancoli.

![afleiding_fout](https://user-images.githubusercontent.com/30574702/119586718-8ad39700-bdcd-11eb-96ad-02ca733639a1.jpg)
Foute afleiding
![afleiding_juist](https://user-images.githubusercontent.com/30574702/119586727-8d35f100-bdcd-11eb-82de-c13ca101fbca.jpg)
Juist afleiding
